### PR TITLE
[GH-11] feat: correct `STATIC_URL` to use full localhost URL

### DIFF
--- a/src/project_core/settings.py
+++ b/src/project_core/settings.py
@@ -121,7 +121,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "http://localhost:8888"
 STATIC_ROOT = BASE_DIR.parent / "staticfiles"
 
 # Default primary key field type


### PR DESCRIPTION
Updated `STATIC_URL` in `settings.py` to `http://localhost:8888`
for proper resolution of static resources during local development.
